### PR TITLE
Add responsive header navigation

### DIFF
--- a/fuelcrate/css/styles.css
+++ b/fuelcrate/css/styles.css
@@ -62,3 +62,68 @@ body {
     flex-direction: column;
   }
 }
+
+/* Header navigation */
+.fc-header {
+  padding: 1rem 0;
+}
+
+.logo {
+  font-weight: bold;
+  color: var(--fc-primary);
+  text-decoration: none;
+}
+
+.nav ul {
+  list-style: none;
+}
+
+.nav ul li a {
+  color: var(--fc-secondary);
+  text-decoration: none;
+}
+
+.nav ul li a:hover {
+  text-decoration: underline;
+}
+
+.nav-toggle {
+  display: none;
+  width: 24px;
+  height: 2px;
+  background: var(--fc-secondary);
+  border: none;
+  position: relative;
+  cursor: pointer;
+}
+
+.nav-toggle::before,
+.nav-toggle::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 24px;
+  height: 2px;
+  background: var(--fc-secondary);
+}
+
+.nav-toggle::before {
+  top: -6px;
+}
+
+.nav-toggle::after {
+  top: 6px;
+}
+
+@media (max-width: 768px) {
+  #nav ul {
+    display: none;
+    flex-direction: column;
+  }
+  #nav.open ul {
+    display: flex;
+  }
+  .nav-toggle {
+    display: block;
+  }
+}

--- a/fuelcrate/index.html
+++ b/fuelcrate/index.html
@@ -7,6 +7,21 @@
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
+<header class="fc-header">
+  <div class="container flex space-between">
+    <a href="#" class="logo">FuelCrate</a>
+    <nav id="nav" class="nav">
+      <ul class="flex gap-lg">
+        <li><a href="#about">About</a></li>
+        <li><a href="#how">How It Works</a></li>
+        <li><a href="#products">Products</a></li>
+        <li><a href="#host">Host FuelCrate</a></li>
+        <li><a href="#contact" class="btn">Contact</a></li>
+      </ul>
+    </nav>
+    <button id="navToggle" class="nav-toggle" aria-label="Menu"></button>
+  </div>
+</header>
 
     <script src="js/main.js" defer></script>
 </body>

--- a/fuelcrate/js/main.js
+++ b/fuelcrate/js/main.js
@@ -1,2 +1,3 @@
 // Scripts for the FuelCrate marketing site
 
+document.getElementById('navToggle').addEventListener('click',()=>{document.getElementById('nav').classList.toggle('open');});


### PR DESCRIPTION
## Summary
- add header navigation to index.html
- style new header elements and mobile nav
- toggle nav menu with small JS snippet

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685641138138832f8fd41defd06132bb