### PR TITLE
Add hero section

### DIFF
--- a/fuelcrate/css/styles.css
+++ b/fuelcrate/css/styles.css
@@ -127,3 +127,32 @@ body {
     display: block;
   }
 }
+
+/* Hero section */
+.hero {
+  min-height: 80vh;
+  padding: 2rem;
+  background: linear-gradient(rgba(0,0,0,0.6), rgba(0,0,0,0.6)), url('https://picsum.photos/1600/900?fitness') center/cover no-repeat;
+  color: #fff;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.6);
+}
+
+.btn-primary {
+  background: var(--fc-primary);
+  color: #fff;
+}
+
+.column {
+  flex-direction: column;
+}
+
+.center {
+  justify-content: center;
+  align-items: center;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding: 4rem 1rem;
+  }
+}

--- a/fuelcrate/index.html
+++ b/fuelcrate/index.html
@@ -22,6 +22,11 @@
     <button id="navToggle" class="nav-toggle" aria-label="Menu"></button>
   </div>
 </header>
+<section id="hero" class="hero flex column center text-center">
+  <h1>Healthy Fuel.<br/>Anywhere&nbsp;You&nbsp;Work&nbsp;or&nbsp;Train.</h1>
+  <p>Smart micro-markets stocked with protein-packed snacks, fresh meals, and recovery drinks—managed remotely, always ready.</p>
+  <a href="#host" class="btn btn-primary">Bring FuelCrate to My Facility</a>
+</section>
 
     <script src="js/main.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- add hero section after header with call to action
- style hero background and button
- create flex utility classes and responsive padding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685641c71dd4832f80419ee44ce76167