### PR TITLE
feat(theme): add dark mode with CSS variables and persistent toggle

### DIFF
--- a/src/components/Contact.module.css
+++ b/src/components/Contact.module.css
@@ -18,6 +18,9 @@
   width: 100%;
   padding: 0.5rem;
   margin-top: 0.25rem;
+  background: var(--fc-surface);
+  color: var(--fc-text);
+  border: 1px solid var(--fc-border);
 }
 
 .flex {

--- a/src/components/Footer.module.css
+++ b/src/components/Footer.module.css
@@ -1,5 +1,7 @@
 .footer {
   padding: 2rem 0;
   text-align: center;
-  background: var(--fc-light);
+  background: var(--fc-surface);
+  color: var(--fc-text);
+  border-top: 1px solid var(--fc-border);
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styles from './Header.module.css';
+import ThemeToggle from './ThemeToggle.jsx';
 
 export default function Header() {
   const [isNavOpen, setIsNavOpen] = useState(false);
@@ -27,6 +28,7 @@ export default function Header() {
             <li><a href="#contact" className={styles.btn}>Contact</a></li>
           </ul>
         </nav>
+        <ThemeToggle />
         <button
           id="navToggle"
           className={styles.navToggle}

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -1,6 +1,6 @@
 .header {
-  background: #ffffff;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  background: var(--fc-surface);
+  border-bottom: 1px solid var(--fc-border);
   position: sticky;
   top: 0;
   z-index: 1000;
@@ -18,7 +18,7 @@
 .logo {
   font-size: 1.5rem;
   font-weight: 800;
-  color: #2eca7f; /* your brand green */
+  color: var(--fc-primary);
   letter-spacing: -0.5px;
   text-decoration: none;
 }
@@ -34,7 +34,7 @@
 .nav ul li a {
   font-weight: 500;
   font-size: 1rem;
-  color: #222;
+  color: var(--fc-text);
   text-decoration: none;
   padding: 0.25rem 0.5rem;
   border-radius: 4px;
@@ -42,13 +42,13 @@
 }
 
 .nav ul li a:hover {
-  background: #2eca7f;
-  color: #ffffff;
+  background: var(--fc-primary);
+  color: #fff;
 }
 
 .btn {
-  background: #2eca7f;
-  color: #ffffff;
+  background: var(--fc-primary);
+  color: #fff;
   padding: 0.5rem 1.25rem;
   border-radius: 9999px;
   font-weight: 600;
@@ -57,7 +57,7 @@
 }
 
 .btn:hover {
-  background: #24a866; /* slightly darker green */
+  background: color-mix(in srgb, var(--fc-primary) 85%, black);
 }
 
 /* Mobile styles */
@@ -71,9 +71,9 @@
     position: absolute;
     top: 64px;
     right: 0;
-    background: white;
+    background: var(--fc-surface);
     width: 100%;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+    border: 1px solid var(--fc-border);
   }
 
   .navOpen ul {
@@ -86,6 +86,19 @@
     display: block;
     cursor: pointer;
     font-size: 1.5rem;
-    color: #333;
+    color: var(--fc-text);
   }
+}
+
+.themeToggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.25rem;
+  color: var(--fc-text);
+}
+
+.themeToggle:hover,
+.themeToggle:focus {
+  color: var(--fc-primary);
 }

--- a/src/components/Hero.module.css
+++ b/src/components/Hero.module.css
@@ -5,7 +5,7 @@
   background-position: center;
   background-repeat: no-repeat;
   min-height: 100vh; /* Full viewport height */
-  color: white;
+  color: var(--fc-hero-text);
 
   display: flex;
   flex-direction: column;
@@ -20,7 +20,7 @@
   content: "";
   position: absolute;
   top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0, 0, 0, 0.45); /* Adjust darkness */
+  background: var(--fc-hero-overlay);
   z-index: 1;
 }
 
@@ -45,12 +45,12 @@
 }
 
 .btnPrimary {
-  background-color: #e63946; /* Your brand red */
-  color: white;
+  background-color: var(--fc-primary);
+  color: #fff;
 }
 
 .btnPrimary:hover {
-  background-color: #d62828; /* Darker hover red */
+  background-color: color-mix(in srgb, var(--fc-primary) 85%, black);
 }
 
 /* Responsive tweaks */

--- a/src/components/Host.module.css
+++ b/src/components/Host.module.css
@@ -27,10 +27,12 @@
 }
 
 .pill {
-  background: var(--fc-light);
+  background: var(--fc-surface);
   padding: .75rem 1.25rem;
   border-radius: 999px;
   font-weight: 600;
+  color: var(--fc-text);
+  border: 1px solid var(--fc-border);
 }
 
 .btn {

--- a/src/components/How.module.css
+++ b/src/components/How.module.css
@@ -20,9 +20,9 @@
 
 .step {
   padding: 1rem;
-  background: #fff;
+  background: var(--fc-surface);
   border-radius: 8px;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  border: 1px solid var(--fc-border);
 }
 
 .container {

--- a/src/components/Products.module.css
+++ b/src/components/Products.module.css
@@ -16,7 +16,8 @@
 .card {
   overflow: hidden;
   border-radius: 8px;
-  background: #fff;
+  background: var(--fc-surface);
+  border: 1px solid var(--fc-border);
   transition: transform .2s;
 }
 

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -1,0 +1,16 @@
+import { applyTheme, isDarkPreferred } from '../theme.js';
+import styles from './Header.module.css';
+
+function ThemeToggle() {
+  return (
+    <button
+      className={styles.themeToggle}
+      aria-label="Toggle dark mode"
+      onClick={() => applyTheme(!isDarkPreferred())}
+    >
+      🌓
+    </button>
+  );
+}
+
+export default ThemeToggle;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './styles/variables.css';
+import { applyTheme, isDarkPreferred } from './theme.js';
+
+applyTheme(isDarkPreferred());
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,7 +1,39 @@
 :root {
-  --fc-primary: #1ec06e;
-  --fc-secondary: #101820;
-  --fc-accent: #20c8ff;
-  --fc-light: #f7f9fa;
   --fc-font: 'Inter', Arial, sans-serif;
+
+  /* Light theme (existing / refined) */
+  --fc-bg: #ffffff;
+  --fc-surface: #f7f9fa;
+  --fc-text: #0b0c0f;
+  --fc-muted: #6b7280;
+  --fc-border: #e5e7eb;
+
+  --fc-primary: #1ec06e;
+  --fc-accent: #20c8ff;
+  --fc-link: #1166cc;
+
+  --fc-hero-overlay: rgba(0, 0, 0, 0.45);
+  --fc-hero-text: #ffffff;
+}
+
+:root[data-theme="dark"] {
+  --fc-bg: #0b0b0c;
+  --fc-surface: #141418;
+  --fc-text: #e9edf2;
+  --fc-muted: #9aa3af;
+  --fc-border: #25282e;
+
+  --fc-primary: #1ec06e;
+  --fc-accent: #8ad9ff;
+  --fc-link: #8ad9ff;
+
+  --fc-hero-overlay: rgba(0, 0, 0, 0.3);
+  --fc-hero-text: #e9edf2;
+}
+
+/* Base application */
+html, body {
+  background: var(--fc-bg);
+  color: var(--fc-text);
+  font-family: var(--fc-font);
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,9 @@
+export const isDarkPreferred = () =>
+  localStorage.getItem('theme')
+    ? localStorage.getItem('theme') === 'dark'
+    : window.matchMedia?.('(prefers-color-scheme: dark)').matches;
+
+export const applyTheme = (dark) => {
+  document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+  localStorage.setItem('theme', dark ? 'dark' : 'light');
+};


### PR DESCRIPTION
## Summary
- introduce light and dark palettes via CSS variables and base application styles
- add theme preference detection with persistent toggle
- refactor component modules to use tokens for colors and surfaces

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68ba1fa4dc90832ba2d1ffeebc425840